### PR TITLE
Use whatwg fetch ver 2.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14239,9 +14239,9 @@
       "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
     },
     "whatwg-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+      "version": "2.0.4",
+      "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react-helmet": "^5.2.0",
     "react-router-dom": "^4.3.1",
     "save": "^2.3.2",
-    "styled-components": "^4.0.2"
+    "styled-components": "^4.0.2",
+    "whatwg-fetch": "^2.0.4"
   },
   "keywords": [
     "gatsby"


### PR DESCRIPTION
Just did `npm install whatwg-fetch@2.0.4 --save` and voila!

Instead of directly manipulating package-lock.json, we should specify the whatwg-fetch version = 2.0.4 in package.json and it updated package-lock.json via the npm install command

See #24 for the previous attempt which was reverted.