### PR TITLE
Prototype for users/userId/invites/invitationId page

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -2,6 +2,7 @@ import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin'
 import * as Twit from 'twit'
 import * as express from 'express'
+import { resolve } from 'url';
 
 interface Auth {
   uid: string
@@ -98,7 +99,34 @@ userApp.get('/users/:userId/invites', (request, response) => {
 })
 
 userApp.get('/users/:userId/invites/:invitationId', (request, response) => {
-  response.send("hello world /users/:userId/invites/:invitationId")
+  firestore
+    .collection('users').doc(request.params.userId)
+    .collection('invites').doc(request.params.invitationId).get().then(invitationDoc => {
+      //This should actually be rendered by React SSR
+      const html =
+        '<!DOCTYPE html>' +
+        '<html>' +
+        '  <head>' +
+        '    <meta charset="UTF-8">' +
+        '    <meta name="twitter:card" content="' + invitationDoc.data()['twitter:card'] + '" />' +
+        '    <meta name="twitter:site" content="' + invitationDoc.data()['twitter:site'] + '" />' +
+        '    <meta name="twitter:creator" content="' + invitationDoc.data()['twitter:creator'] + '" />' +
+        '    <meta property="og:url" content="' + invitationDoc.data()['og:url'] + '" />' +
+        '    <meta property="og:title" content="' + invitationDoc.data()['og:title'] + '" />' +
+        '    <meta property="og:description" content="' + invitationDoc.data()['og:description'] + '" />' +
+        '    <meta property="og:image" content="' + invitationDoc.data()['og:image'] + '" />' +
+        '    <title>title</title>' +
+        '  </head>' +
+        '  <body>' +
+        '        HEEELLLOOOOO WHAAAAATTT THE FFFFFFFFFFFF!!!!!!!  ' + 
+        '  </body>' +
+        '</html>'
+
+        response.send(html)
+    }).catch(err => {
+      response.status(404)
+      response.send("No such invitation")      
+    })
 })
 
 // export const helloWorld = functions.https.onRequest((request, response) => {


### PR DESCRIPTION
Refs #10

You can see the behavior from this URL:
https://pinvite.fun/users/xxxx/invites/aaaa?no-cache=1

As I created a dummy data for user = `xxxx` and invitationId = `aaaa`.

![image](https://user-images.githubusercontent.com/7414320/48740280-3601b380-ec9a-11e8-9468-45dd1506251e.png)
