### PR TITLE
POST only the necessary parameters in the body 

### DIFF
--- a/src/pages/invite.js
+++ b/src/pages/invite.js
@@ -105,8 +105,6 @@ class InvitePage extends React.Component {
 
   createPostBody() {
     return ({
-      amount:        this.state.amount,
-      currency:      this.state.currency,
       description:   this.state.description,
       image_url:     this.imageUrl(),
       title:         this.state.title


### PR DESCRIPTION
Closes #11 

The necessary parameters for the OGP tags are listed here:
https://developer.twitter.com/en/docs/tweets/optimize-with-cards/guides/getting-started.html


```js
{
  'twitter:card'    : "summary_large_image",       //fixed value
  'twitter:site'    : "@orgpinvite",               //fixed value
  'twitter:creator' : userDoc.data().twitter_user, //data to be registered at initial login, not when data for tweet is POST-ed
  'og:url'          : url,                         //to be generated AFTER the POST is done
  'og:title'        : request.body.title,          //needed in the POST body parameter
  'og:description'  : request.body.description,    //needed in the POST body parameter
  'og:image'        : request.body.image_url       //needed in the POST body parameter
}
```